### PR TITLE
fix: no render on preload none

### DIFF
--- a/site/app/_components/MediaTheme.tsx
+++ b/site/app/_components/MediaTheme.tsx
@@ -10,10 +10,11 @@ type MediaThemeProps = {
   theme: any;
   children?: ReactNode;
   className?: string;
+  defaultDuration?: number;
 };
 
 export default function MediaThemeComponent(props: MediaThemeProps) {
-  const { name, theme, children, className } = props;
+  const { name, theme, children, className, defaultDuration } = props;
 
   return (
     <>
@@ -25,6 +26,7 @@ export default function MediaThemeComponent(props: MediaThemeProps) {
         className={clsx('block w-full', className)}
         key={`media-theme-${name}`}
         template={`media-theme-${name}`}
+        defaultDuration={defaultDuration}
         {...theme.templates.html.props}
       >
         {children}

--- a/site/app/_components/ThemePreview.tsx
+++ b/site/app/_components/ThemePreview.tsx
@@ -20,7 +20,7 @@ export default function ThemePreview(props: ThemePreviewProps) {
     <>
       <div className="border-ctx border -m-0.5px relative grid gap-x-2 gap-y-1 p-1 pb-2 md:px-2 md:py-1.5">
         <div className="relative bg-white">
-          <MediaTheme name={theme._meta.path} theme={theme}>
+          <MediaTheme name={theme._meta.path} theme={theme} defaultDuration={63}>
             <HlsVideo
               suppressHydrationWarning
               className="aspect-video block h-fit"

--- a/site/app/_components/ThemePreview.tsx
+++ b/site/app/_components/ThemePreview.tsx
@@ -28,6 +28,7 @@ export default function ThemePreview(props: ThemePreviewProps) {
               src="https://stream.mux.com/clGdHA024AM9yU9fueA8Kr601LNt02oVfHMVGceXtQO8DI.m3u8"
               poster="https://image.mux.com/clGdHA024AM9yU9fueA8Kr601LNt02oVfHMVGceXtQO8DI/thumbnail.webp?time=52"
               crossOrigin="anonymous"
+              preload="none"
             >
               <track
                 label="thumbnails"

--- a/themes/demuxed-2022/template.html
+++ b/themes/demuxed-2022/template.html
@@ -229,15 +229,12 @@
 
 <media-controller
   breakpoints="xs:360 sm:600 md:760 lg:960 xl:1100"
-  nodefaultstore="{{nodefaultstore}}"
   defaultsubtitles="{{defaultsubtitles}}"
   defaultduration="{{defaultduration}}"
   gesturesdisabled="{{disabled}}"
   hotkeys="{{hotkeys}}"
   nohotkeys="{{nohotkeys}}"
-  audio="{{audio}}"
   defaultstreamtype="on-demand"
-  exportparts="layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer"
 >
   <slot name="media" slot="media"></slot>
   <slot name="poster" slot="poster"></slot>

--- a/themes/demuxed-2022/template.html
+++ b/themes/demuxed-2022/template.html
@@ -228,12 +228,16 @@
 </style>
 
 <media-controller
+  breakpoints="xs:360 sm:600 md:760 lg:960 xl:1100"
+  nodefaultstore="{{nodefaultstore}}"
   defaultsubtitles="{{defaultsubtitles}}"
+  defaultduration="{{defaultduration}}"
   gesturesdisabled="{{disabled}}"
   hotkeys="{{hotkeys}}"
   nohotkeys="{{nohotkeys}}"
   audio="{{audio}}"
-  breakpoints="xs:360 sm:600 md:760 lg:960 xl:1100"
+  defaultstreamtype="on-demand"
+  exportparts="layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer"
 >
   <slot name="media" slot="media"></slot>
   <slot name="poster" slot="poster"></slot>

--- a/themes/microvideo/template.html
+++ b/themes/microvideo/template.html
@@ -401,9 +401,10 @@
 </template>
 
 <media-controller
+  style="--_control-bar-place-self:{{controlbarplace ?? 'unset'}}"
   nodefaultstore="{{nodefaultstore}}"
   defaultsubtitles="{{defaultsubtitles}}"
-  style="--_control-bar-place-self:{{controlbarplace ?? 'unset'}}"
+  defaultduration="{{defaultduration}}"
   gesturesdisabled="{{disabled}}"
   hotkeys="{{hotkeys}}"
   nohotkeys="{{nohotkeys}}"

--- a/themes/microvideo/template.html
+++ b/themes/microvideo/template.html
@@ -408,6 +408,7 @@
   hotkeys="{{hotkeys}}"
   nohotkeys="{{nohotkeys}}"
   audio="{{audio}}"
+  defaultstreamtype="on-demand"
   exportparts="layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer"
 >
   <slot name="media" slot="media"></slot>

--- a/themes/microvideo/template.html
+++ b/themes/microvideo/template.html
@@ -400,17 +400,19 @@
   </span>
 </template>
 
+<!--
+  controlbarplace targets the place-self CSS property of the controlbar.
+  e.g. controlbarplace="center center" will center the controlbar.
+-->
+
 <media-controller
   style="--_control-bar-place-self:{{controlbarplace ?? 'unset'}}"
-  nodefaultstore="{{nodefaultstore}}"
   defaultsubtitles="{{defaultsubtitles}}"
   defaultduration="{{defaultduration}}"
   gesturesdisabled="{{disabled}}"
   hotkeys="{{hotkeys}}"
   nohotkeys="{{nohotkeys}}"
-  audio="{{audio}}"
   defaultstreamtype="on-demand"
-  exportparts="layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer"
 >
   <slot name="media" slot="media"></slot>
   <slot name="poster" slot="poster"></slot>

--- a/themes/minimal/template.html
+++ b/themes/minimal/template.html
@@ -313,6 +313,7 @@
   hotkeys="{{hotkeys}}"
   nohotkeys="{{nohotkeys}}"
   audio="{{audio}}"
+  defaultstreamtype="on-demand"
   exportparts="layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer"
 >
   <slot name="media" slot="media"></slot>

--- a/themes/minimal/template.html
+++ b/themes/minimal/template.html
@@ -308,7 +308,9 @@
 </template>
 
 <media-controller
+  nodefaultstore="{{nodefaultstore}}"
   defaultsubtitles="{{defaultsubtitles}}"
+  defaultduration="{{defaultduration}}"
   gesturesdisabled="{{disabled}}"
   hotkeys="{{hotkeys}}"
   nohotkeys="{{nohotkeys}}"

--- a/themes/minimal/template.html
+++ b/themes/minimal/template.html
@@ -308,15 +308,12 @@
 </template>
 
 <media-controller
-  nodefaultstore="{{nodefaultstore}}"
   defaultsubtitles="{{defaultsubtitles}}"
   defaultduration="{{defaultduration}}"
   gesturesdisabled="{{disabled}}"
   hotkeys="{{hotkeys}}"
   nohotkeys="{{nohotkeys}}"
-  audio="{{audio}}"
   defaultstreamtype="on-demand"
-  exportparts="layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer"
 >
   <slot name="media" slot="media"></slot>
   <slot name="poster" slot="poster"></slot>

--- a/themes/yt/template.html
+++ b/themes/yt/template.html
@@ -60,15 +60,12 @@
 
 <media-controller
   breakpoints="md:480"
-  nodefaultstore="{{nodefaultstore}}"
   defaultsubtitles="{{defaultsubtitles}}"
   defaultduration="{{defaultduration}}"
   gesturesdisabled="{{disabled}}"
   hotkeys="{{hotkeys}}"
   nohotkeys="{{nohotkeys}}"
-  audio="{{audio}}"
   defaultstreamtype="on-demand"
-  exportparts="layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer"
 >
   <slot name="media" slot="media"></slot>
   <slot name="poster" slot="poster"></slot>

--- a/themes/yt/template.html
+++ b/themes/yt/template.html
@@ -58,7 +58,18 @@
   }
 </style>
 
-<media-controller breakpoints="md:480">
+<media-controller
+  breakpoints="md:480"
+  nodefaultstore="{{nodefaultstore}}"
+  defaultsubtitles="{{defaultsubtitles}}"
+  defaultduration="{{defaultduration}}"
+  gesturesdisabled="{{disabled}}"
+  hotkeys="{{hotkeys}}"
+  nohotkeys="{{nohotkeys}}"
+  audio="{{audio}}"
+  defaultstreamtype="on-demand"
+  exportparts="layer, media-layer, poster-layer, vertical-layer, centered-layer, gesture-layer"
+>
   <slot name="media" slot="media"></slot>
   <slot name="poster" slot="poster"></slot>
 


### PR DESCRIPTION
fix #37

fixes an issue where the microvideo and minimal themes wouldn't render with preload none.

preload none is more sensible for the theme list previews.