### PR TITLE
Add some routes to list themes/players in JSON format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@player.style/microvideo": "0.0.5",
         "@player.style/minimal": "0.0.5",
         "@player.style/yt": "0.0.5",
+        "hls.js": "^1.5.13",
         "media-chrome": "^3.2.3"
       },
       "devDependencies": {
@@ -4336,9 +4337,10 @@
       }
     },
     "node_modules/hls.js": {
-      "version": "1.5.11",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.11.tgz",
-      "integrity": "sha512-q3We1izi2+qkOO+TvZdHv+dx6aFzdtk3xc1/Qesrvto4thLTT/x/1FK85c5h1qZE4MmMBNgKg+MIW8nxQfxwBw=="
+      "version": "1.5.13",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.13.tgz",
+      "integrity": "sha512-xRgKo84nsC7clEvSfIdgn/Tc0NOT+d7vdiL/wvkLO+0k0juc26NRBPPG1SfB8pd5bHXIjMW/F5VM8VYYkOYYdw==",
+      "license": "Apache-2.0"
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@player.style/microvideo": "0.0.5",
     "@player.style/minimal": "0.0.5",
     "@player.style/yt": "0.0.5",
+    "hls.js": "^1.5.13",
     "media-chrome": "^3.2.3"
   },
   "devDependencies": {

--- a/site/app/api/players/route.ts
+++ b/site/app/api/players/route.ts
@@ -1,0 +1,6 @@
+import { getCollection } from '../../_utils/content';
+const themes = await getCollection('players');
+
+export async function GET(request: Request) {
+  return Response.json({ themes })
+}

--- a/site/app/api/themes/route.ts
+++ b/site/app/api/themes/route.ts
@@ -1,0 +1,6 @@
+import { getCollection } from '../../_utils/content';
+const themes = await getCollection('themes');
+
+export async function GET(request: Request) {
+  return Response.json({ themes })
+}


### PR DESCRIPTION
I was hacking around on some stuff over the holiday and found myself wanting to be able to programmatically retrieve available themes. This just exposes the `themes` and `players` content collections as a route directly.

Also added hls.js as a dependency because otherwise the entire project was blowing up.