### PR TITLE
site: use mux-video WC for casting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -886,6 +886,18 @@
         "react": ">=16"
       }
     },
+    "node_modules/@mux/mux-video": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.20.2.tgz",
+      "integrity": "sha512-CqkK9EZZWdQE4U62JKlmWDskirT+D9C4suh2tSqKb2CA/0S4ybbbrVWcCKF7xfadUacfKO1yPsOKbe46F6phVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/playback-core": "0.25.2",
+        "castable-video": "~1.0.9",
+        "custom-media-element": "~1.3.1",
+        "media-tracks": "~0.3.2"
+      }
+    },
     "node_modules/@mux/mux-video-react": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/@mux/mux-video-react/-/mux-video-react-0.11.1.tgz",
@@ -907,6 +919,16 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mux/mux-video/node_modules/@mux/playback-core": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.25.2.tgz",
+      "integrity": "sha512-vrBbCgLHwmPpVxF0QGj+sXHUVXSxgDJJhVm8pxPXEkbw0vjPNHTXgAd/Ty6JA0vZ0ZjoQuAa17AxJ+c02JYeWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hls.js": "~1.5.11",
+        "mux-embed": "~5.2.0"
       }
     },
     "node_modules/@mux/playback-core": {
@@ -2574,6 +2596,15 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/castable-video": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.0.10.tgz",
+      "integrity": "sha512-tJgUv+8/zE191y8EKojvB0eKIyKA9obIttd6Wpdm6x2qBmuwZ7wDgzVCSmf5cN2v9jBiuu0s7O5poz8a8cFX/w==",
+      "license": "MIT",
+      "dependencies": {
+        "custom-media-element": "~1.3.2"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -10520,6 +10551,7 @@
       "dependencies": {
         "@mdx-js/loader": "^3.0.1",
         "@mdx-js/react": "^3.0.1",
+        "@mux/mux-video": "^0.20.2",
         "@mux/mux-video-react": "^0.11.0",
         "@next/mdx": "^14.2.3",
         "clsx": "^2.1.1",

--- a/site/app/_components/PlayerHero.tsx
+++ b/site/app/_components/PlayerHero.tsx
@@ -7,14 +7,6 @@ import clsx from 'clsx';
 import mediaAssets from '@/media-assets';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      'mux-video': any;
-    }
-  }
-}
-
 type PlayerHeroProps = {
   theme: any;
   params: any;
@@ -128,6 +120,9 @@ export default function PlayerHero(props: PlayerHeroProps) {
                       default
                       kind="metadata"
                       src={mediaAssets[asset].thumbnails}
+                      // Use key so the track element is replaced if src changes.
+                      // custom-media-element doesn't support track attr changes.
+                      key={mediaAssets[asset].thumbnails}
                     />
                   </Video>
                 </MediaTheme>

--- a/site/app/_components/PlayerHero.tsx
+++ b/site/app/_components/PlayerHero.tsx
@@ -1,11 +1,19 @@
 'use client';
 
-import HlsVideo from 'hls-video-element/react';
+import Video from '@/app/_components/Video';
 import MediaTheme from '@/app/_components/MediaTheme';
 import { FormEvent, useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 import mediaAssets from '@/media-assets';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'mux-video': any;
+    }
+  }
+}
 
 type PlayerHeroProps = {
   theme: any;
@@ -109,14 +117,11 @@ export default function PlayerHero(props: PlayerHeroProps) {
                 }}
               >
                 <MediaTheme name={props.params.slug} theme={theme}>
-                  <HlsVideo
-                    suppressHydrationWarning
+                  <Video
                     className="block"
                     slot="media"
                     src={mediaAssets[asset].src}
                     poster={!theme.audio ? mediaAssets[asset].poster : undefined}
-                    crossOrigin="anonymous"
-                    playsInline
                   >
                     <track
                       label="thumbnails"
@@ -124,7 +129,7 @@ export default function PlayerHero(props: PlayerHeroProps) {
                       kind="metadata"
                       src={mediaAssets[asset].thumbnails}
                     />
-                  </HlsVideo>
+                  </Video>
                 </MediaTheme>
               </div>
             </div>

--- a/site/app/_components/ThemePreview.tsx
+++ b/site/app/_components/ThemePreview.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import clsx from 'clsx';
-import HlsVideo from 'hls-video-element/react';
+import Video from '@/app/_components/Video';
 import MediaTheme from '@/app/_components/MediaTheme';
 import Link from 'next/link';
 import AuthorLink from './AuthorLink';
@@ -35,15 +35,12 @@ export default function ThemePreview(props: ThemePreviewProps) {
             }}
           >
             <MediaTheme name={theme._meta.path} theme={theme} defaultDuration={63}>
-              <HlsVideo
-                suppressHydrationWarning
+              <Video
                 className="block"
                 slot="media"
                 src={mediaAssets[asset].src}
                 poster={!theme.audio ? mediaAssets[asset].poster : undefined}
-                crossOrigin="anonymous"
                 preload="none"
-                playsInline
               >
                 <track
                   label="thumbnails"
@@ -51,7 +48,7 @@ export default function ThemePreview(props: ThemePreviewProps) {
                   kind="metadata"
                   src={mediaAssets[asset].thumbnails}
                 />
-              </HlsVideo>
+              </Video>
             </MediaTheme>
           </div>
         </div>

--- a/site/app/_components/Video.tsx
+++ b/site/app/_components/Video.tsx
@@ -19,7 +19,13 @@ type VideoProps = DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLV
 
 export default function Video(props: VideoProps) {
   return (
-    <mux-video suppressHydrationWarning crossOrigin="anonymous" playsInline {...props}>
+    <mux-video
+      suppressHydrationWarning
+      crossOrigin="anonymous"
+      playsInline
+      cast-src={props.src}
+      {...props}
+    >
       {props.children}
     </mux-video>
   );

--- a/site/app/_components/Video.tsx
+++ b/site/app/_components/Video.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import '@mux/mux-video';
+import { DetailedHTMLProps, VideoHTMLAttributes } from 'react';
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'mux-video': any;
+    }
+  }
+}
+
+type VideoProps = DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> & {
+  className?: string;
+  slot?: string;
+  children?: React.ReactNode;
+};
+
+export default function Video(props: VideoProps) {
+  return (
+    <mux-video suppressHydrationWarning crossOrigin="anonymous" playsInline {...props}>
+      {props.children}
+    </mux-video>
+  );
+}

--- a/site/package.json
+++ b/site/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@mdx-js/loader": "^3.0.1",
     "@mdx-js/react": "^3.0.1",
+    "@mux/mux-video": "^0.20.2",
     "@mux/mux-video-react": "^0.11.0",
     "@next/mdx": "^14.2.3",
     "clsx": "^2.1.1",

--- a/themes/instaplay/template.html
+++ b/themes/instaplay/template.html
@@ -11,7 +11,6 @@
     --media-font-weight: bold;
     font-size: 16px;
     color: var(--_primary-color);
-    container: media-theme-instaplay / inline-size;
   }
 
   @supports (color: color-mix(in srgb, red, blue)) {
@@ -32,6 +31,7 @@
   media-controller {
     display: block;
     overflow: hidden;
+    container: media-theme-instaplay / inline-size;
   }
 
   media-control-bar {

--- a/themes/vimeonova/template.html
+++ b/themes/vimeonova/template.html
@@ -23,6 +23,7 @@
   }
 
   media-controller {
+    display: block;
     container: media-theme-vimeonova / inline-size;
   }
 


### PR DESCRIPTION
related #57

a bit of a weird one because we have to use the web component to have support for casting and renditions etc and not use the "specialized" React package `mux-video-react` which doesn't have those features out of the box.