### PR TITLE
Explicitly install prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,21 +16,22 @@
         "themes/*"
       ],
       "dependencies": {
-        "@player.style/demuxed-2022": "0.0.6",
-        "@player.style/instaplay": "0.0.1",
-        "@player.style/microvideo": "0.0.5",
-        "@player.style/minimal": "0.0.5",
-        "@player.style/sutro": "0.0.1",
-        "@player.style/tailwind-audio": "0.0.5",
-        "@player.style/vimeonova": "0.0.5",
-        "@player.style/winamp": "0.0.5",
-        "@player.style/yt": "0.0.5",
+        "@player.style/demuxed-2022": "0.0.7",
+        "@player.style/instaplay": "0.0.2",
+        "@player.style/microvideo": "0.0.6",
+        "@player.style/minimal": "0.0.6",
+        "@player.style/sutro": "0.0.2",
+        "@player.style/tailwind-audio": "0.0.6",
+        "@player.style/vimeonova": "0.0.6",
+        "@player.style/winamp": "0.0.6",
+        "@player.style/yt": "0.0.6",
         "media-chrome": "^4.0.0"
       },
       "devDependencies": {
         "chokidar-cli": "^3.0.0",
         "eslint": "^8.57.0",
         "npm-run-all": "^4.1.5",
+        "prettier": "^3.3.3",
         "rimraf": "^6.0.1",
         "turbo": "^2.0.12",
         "typescript": "^5"
@@ -7787,8 +7788,7 @@
     },
     "node_modules/player.style": {
       "resolved": "",
-      "link": true,
-      "version": "0.0.7"
+      "link": true
     },
     "node_modules/pluralize": {
       "version": "8.0.0",
@@ -8002,6 +8002,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "dev": "chokidar --debounce 50 './themes/*/!(dist|.turbo)' -c 'turbo build --force --filter=./$(dirname {path}) && touch ./site/$(dirname {path}).md'"
   },
   "dependencies": {
-    "@player.style/sutro": "0.0.2",
     "@player.style/demuxed-2022": "0.0.7",
     "@player.style/instaplay": "0.0.2",
     "@player.style/microvideo": "0.0.6",
     "@player.style/minimal": "0.0.6",
+    "@player.style/sutro": "0.0.2",
     "@player.style/tailwind-audio": "0.0.6",
     "@player.style/vimeonova": "0.0.6",
     "@player.style/winamp": "0.0.6",
@@ -48,6 +48,7 @@
     "chokidar-cli": "^3.0.0",
     "eslint": "^8.57.0",
     "npm-run-all": "^4.1.5",
+    "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
     "turbo": "^2.0.12",
     "typescript": "^5"


### PR DESCRIPTION
Idk about VSCode, but I couldn't get prettier to work in [Zed](https://zed.dev/) without having it explicitly installed like this