### PR TITLE
site: add template embed method

### DIFF
--- a/site/app/_components/ButtonPickerOption.tsx
+++ b/site/app/_components/ButtonPickerOption.tsx
@@ -27,7 +27,10 @@ export default function ButtonPickerOption(props: ButtonPickerOptionProps) {
     if (term) {
       params.set(type, term);
     } else {
-      params.delete(type);
+      // This is a workaround for a bug where the page without a search query
+      // would not trigger a RSC update.
+      // params.delete(type);
+      params.set(type, term);
     }
     replace(`${pathname}?${params.toString()}`, { scroll: false });
   };

--- a/site/app/_components/DocsInstall.tsx
+++ b/site/app/_components/DocsInstall.tsx
@@ -7,12 +7,14 @@ type DocsInstallProps = {
 };
 
 export default async function DocsInstall({ searchParams }: DocsInstallProps) {
-  const media = findParam(searchParams, 'media') ?? 'video';
+  const media = findParam(searchParams, 'media') || 'video';
   const mediaElement = mediaElements[media as keyof typeof mediaElements];
 
-  const framework = findParam(searchParams, 'framework') ?? 'html';
+  const framework = findParam(searchParams, 'framework') || 'html';
 
   if (framework === 'html') return null;
+
+  const embed = findParam(searchParams, 'embed') ?? 'packaged';
 
   let mediaPackage =
     mediaElement.package?.[framework as keyof typeof mediaElement.package] ??
@@ -22,7 +24,7 @@ export default async function DocsInstall({ searchParams }: DocsInstallProps) {
     mediaPackage = mediaPackage.split('/')[0];
   }
 
-  const installs = ['player.style'];
+  const installs = [embed === 'template' ? 'media-chrome' : 'player.style'];
 
   if (mediaPackage) {
     installs.unshift(mediaPackage);

--- a/site/app/themes/[slug]/page.tsx
+++ b/site/app/themes/[slug]/page.tsx
@@ -171,8 +171,24 @@ export default async function Page(props: ThemePageProps) {
             </div>
           </div>
 
+          <h4 className="text-lg font-medium mb-1">Embed method</h4>
+
+          <ButtonPicker type="embed">
+            <ButtonPickerOption
+              selected
+              title="Packaged"
+              value=""
+              className="hover:bg-yellow [&.active]:bg-yellow"
+            />
+            <ButtonPickerOption
+              title="Template"
+              value="template"
+              className="hover:bg-yellow [&.active]:bg-yellow"
+            />
+          </ButtonPicker>
+
           <DocsInstall searchParams={props.searchParams} />
-          <DocsEmbed searchParams={props.searchParams} theme={props.params.slug} />
+          <DocsEmbed searchParams={props.searchParams} theme={entry} name={props.params.slug} />
         </Grid>
       </div>
     </>


### PR DESCRIPTION
test URL: https://player-style-git-template-embed-mux.vercel.app/themes/instaplay

this PR adds a new choice for the embed method. either `packaged` or `template`. 
the `template` method shows all the html theme markup in the embed code that can easily be edited.

Vue and Svelte were the most difficult to get this working in the copy / paste code because they don't provide an easy way to just render a plain `<template>` element. In those langs template elements are processed.

in Vue the inner html is not added to template's internal document fragment and inline style and script tags cause build errors because Vue wants these things in the top level style and script tag.

in Svelte the template tag seemed to be stripped and it tried to process the curly braces in the Media Chrome template syntax. 

I searched a bunch to try and disable this `template` processing but I couldn't find any answers.
the workaround in this PR is to create the template element in javascript (in the top-level script tag) and then when the app is mounted via lifecycle hooks media-theme's template property is set to the created template element.

for each template embed code I made a test Codesandbox to see if they worked
https://codesandbox.io/dashboard/drafts?workspace=1ed1312b-2336-4ff0-bf7a-2b8f2c993753