### PR TITLE
site: add playback-id to mux-video, UI re-order

### DIFF
--- a/site/app/themes/[slug]/page.tsx
+++ b/site/app/themes/[slug]/page.tsx
@@ -58,7 +58,32 @@ export default async function Page(props: ThemePageProps) {
 
           <hr className="border-putty mb-2" />
 
-          <h3 className="text-2xl font-semibold mb-1">Use this theme</h3>
+          <h3 className="text-2xl font-semibold mb-1">
+            Customize theme <ThemeColorPopover />
+          </h3>
+
+          <div className="flex flex-col sm:flex-row gap-0.5 mb-2">
+            <div className="flex items-center gap-0.25">
+              <ColorPicker id="primary-color" defaultValue="#ffffff" />
+              <label htmlFor="primary-color" className="uppercase text-sm font-mono">
+                Primary
+              </label>
+            </div>
+            <div className="flex items-center gap-0.25">
+              <ColorPicker id="secondary-color" defaultValue="#ffffff" />
+              <label htmlFor="secondary-color" className="uppercase text-sm font-mono">
+                Secondary
+              </label>
+            </div>
+            <div className="flex items-center gap-0.25">
+              <ColorPicker id="accent-color" defaultValue="#ffffff" />
+              <label htmlFor="accent-color" className="uppercase text-sm font-mono">
+                Accent
+              </label>
+            </div>
+          </div>
+
+          <h3 className="text-2xl font-semibold mb-1">Use theme</h3>
 
           <h4 className="text-lg font-medium mb-1">Pick your media type or platform</h4>
 
@@ -146,30 +171,6 @@ export default async function Page(props: ThemePageProps) {
               className="hover:bg-orange [&.active]:bg-orange"
             />
           </ButtonPicker>
-          
-          <h4 className="text-lg font-medium mb-1">
-            Customize your theme <ThemeColorPopover />
-          </h4>
-          <div className="flex flex-col sm:flex-row gap-0.5 mb-2">
-            <div className="flex items-center gap-0.25">
-              <ColorPicker id="primary-color" defaultValue="#ffffff" />
-              <label htmlFor="primary-color" className="uppercase text-sm font-mono">
-                Primary
-              </label>
-            </div>
-            <div className="flex items-center gap-0.25">
-              <ColorPicker id="secondary-color" defaultValue="#ffffff" />
-              <label htmlFor="secondary-color" className="uppercase text-sm font-mono">
-                Secondary
-              </label>
-            </div>
-            <div className="flex items-center gap-0.25">
-              <ColorPicker id="accent-color" defaultValue="#ffffff" />
-              <label htmlFor="accent-color" className="uppercase text-sm font-mono">
-                Accent
-              </label>
-            </div>
-          </div>
 
           <h4 className="text-lg font-medium mb-1">Embed method</h4>
 

--- a/site/media-assets.ts
+++ b/site/media-assets.ts
@@ -1,5 +1,6 @@
 const mediaAssets = {
   landscape: {
+    playbackId: 'fXNzVtmtWuyz00xnSrJg4OJH6PyNo6D02UzmgeKGkP5YQ',
     src: 'https://stream.mux.com/fXNzVtmtWuyz00xnSrJg4OJH6PyNo6D02UzmgeKGkP5YQ.m3u8',
     poster: 'https://image.mux.com/fXNzVtmtWuyz00xnSrJg4OJH6PyNo6D02UzmgeKGkP5YQ/thumbnail.webp?time=52',
     thumbnails: 'https://image.mux.com/fXNzVtmtWuyz00xnSrJg4OJH6PyNo6D02UzmgeKGkP5YQ/storyboard.vtt',
@@ -8,6 +9,7 @@ const mediaAssets = {
     byline: 'by Mux'
   },
   portrait: {
+    playbackId: '1EFcsL5JET00t00mBv01t00xt00T4QeNQtsXx2cKY6DLd7RM',
     src: 'https://stream.mux.com/1EFcsL5JET00t00mBv01t00xt00T4QeNQtsXx2cKY6DLd7RM.m3u8',
     poster: 'https://image.mux.com/1EFcsL5JET00t00mBv01t00xt00T4QeNQtsXx2cKY6DLd7RM/thumbnail.webp',
     thumbnails: 'https://image.mux.com/1EFcsL5JET00t00mBv01t00xt00T4QeNQtsXx2cKY6DLd7RM/storyboard.vtt',

--- a/site/media-elements.ts
+++ b/site/media-elements.ts
@@ -28,6 +28,7 @@ const mediaElements = {
   mux: {
     tag: 'mux-video',
     src: 'https://stream.mux.com/fXNzVtmtWuyz00xnSrJg4OJH6PyNo6D02UzmgeKGkP5YQ.m3u8',
+    playbackId: 'fXNzVtmtWuyz00xnSrJg4OJH6PyNo6D02UzmgeKGkP5YQ',
     package: {
       default: '@mux/mux-video',
       react: '@mux/mux-video-react',


### PR DESCRIPTION
test url: https://player-style-git-mux-playback-id-mux.vercel.app/themes/instaplay?accent-color=ff0000&framework=react&media=mux&primary-color=00e1ff&embed=&asset=landscape

- uses the `playback-id` attribute instead of src for the mux-video element
- re-orders the color picker to be first because that is also visible in the player at the top
  the other embed buttons only manipulate the bottom copy / paste code