### PR TITLE
site: remove sticky causing CLS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,16 +19,16 @@
         "media-chrome": "^4.1.0"
       },
       "devDependencies": {
-        "@player.style/demuxed-2022": "0.0.7",
-        "@player.style/instaplay": "0.0.2",
-        "@player.style/microvideo": "0.0.6",
-        "@player.style/minimal": "0.0.6",
-        "@player.style/sutro": "0.0.2",
-        "@player.style/sutro-audio": "0.0.1",
-        "@player.style/tailwind-audio": "0.0.6",
-        "@player.style/vimeonova": "0.0.6",
-        "@player.style/winamp": "0.0.6",
-        "@player.style/yt": "0.0.6",
+        "@player.style/demuxed-2022": "0.0.8",
+        "@player.style/instaplay": "0.0.3",
+        "@player.style/microvideo": "0.0.7",
+        "@player.style/minimal": "0.0.7",
+        "@player.style/sutro": "0.0.3",
+        "@player.style/sutro-audio": "0.0.2",
+        "@player.style/tailwind-audio": "0.0.7",
+        "@player.style/vimeonova": "0.0.7",
+        "@player.style/winamp": "0.0.7",
+        "@player.style/yt": "0.0.7",
         "chokidar-cli": "^3.0.0",
         "eslint": "^8.57.0",
         "npm-run-all": "^4.1.5",
@@ -8378,8 +8378,7 @@
     },
     "node_modules/player.style": {
       "resolved": "",
-      "link": true,
-      "version": "0.0.8"
+      "link": true
     },
     "node_modules/pluralize": {
       "version": "8.0.0",
@@ -11286,6 +11285,7 @@
       "devDependencies": {
         "@content-collections/core": "^0.6.0",
         "@content-collections/next": "^0.2.0",
+        "@tailwindcss/container-queries": "^0.1.1",
         "@types/mdx": "^2.0.13",
         "@types/node": "^20",
         "@types/react": "^18",

--- a/site/app/(home)/page.tsx
+++ b/site/app/(home)/page.tsx
@@ -20,7 +20,7 @@ export default async function Home({ searchParams }: HomeProps) {
 
   return (
     <>
-      <Hero title="Find your Player">
+      <Hero title="Find your Player" className="md:min-h-[253px] lg:min-h-[328px]">
         Look on our player theme treasures; compatible with most web video and audio players.{' '}
         <Link href="/about">Learn more about the project</Link>.
       </Hero>

--- a/site/app/_components/Hero.tsx
+++ b/site/app/_components/Hero.tsx
@@ -1,14 +1,16 @@
 import Grid from './Grid';
+import clsx from 'clsx';
 
 type HeroProps = {
   title: string;
   children: React.ReactNode;
+  className?: string;
 };
 
 export default function Hero(props: HeroProps) {
   return (
     <>
-      <Grid className="text-center">
+      <Grid className={clsx('text-center', props.className)}>
         <h1 className="font-display text-2xl sm:text-4xl md:text-5xl lg:text-6xl tracking-wide leading-heading font-normal uppercase whitespace-pre-line mx-auto max-w-32 mb-1">
           {props.title}
         </h1>

--- a/site/app/_components/MediaTheme.tsx
+++ b/site/app/_components/MediaTheme.tsx
@@ -40,7 +40,7 @@ export default function MediaThemeComponent(props: MediaThemeProps) {
         dangerouslySetInnerHTML={{ __html: `${theme.templates.html.content}` }}
       />
       <MediaTheme
-        className={clsx('block w-full', className)}
+        className={clsx('block w-full h-full', className, theme.themeProps?.className)}
         key={theme.templates.html.content}
         template={`media-theme-${name}`}
         defaultDuration={defaultDuration}

--- a/site/app/_components/NavBar.tsx
+++ b/site/app/_components/NavBar.tsx
@@ -7,12 +7,12 @@ import MobileNav from './MobileNav';
 export default function NavBar() {
   return (
     <>
-      <div className="border-y -my-1px grid grid-cols-xs sm:grid-cols-sm lg:grid-cols-lg xl:grid-cols-xl bg-putty-light border-ctx-gray text-black set-bg-ctx-putty-light set-border-ctx-gray sticky -top-1px z-50">
+      <div className="h-[57px] md:h-[85px] border-y -my-1px grid grid-cols-xs sm:grid-cols-sm lg:grid-cols-lg xl:grid-cols-xl bg-putty-light border-ctx-gray text-black set-bg-ctx-putty-light set-border-ctx-gray -top-1px z-50">
         <div className="col-start-2 col-end-3 border-x border-ctx-gray">
           <div className="-m-0.5px grid-cols-1 relative h-2 md:h-3 flex items-center justify-between">
             <div className="flex items-center text-sm relative -top-1px md:-top-2px">
               <Link className="block relative pl-0.5 sm:pl-1 pr-0.25 md:pr-0.5" href="/">
-                <PlayerStyleLogo className="h-[26px] md:h-[34px]" />
+                <PlayerStyleLogo className="w-[130px] h-[26px] md:w-[170px] md:h-[34px]" />
                 <span className="sr-only">player.style</span>
               </Link>
               <a

--- a/site/app/_components/PlayerHero.tsx
+++ b/site/app/_components/PlayerHero.tsx
@@ -102,8 +102,9 @@ export default function PlayerHero(props: PlayerHeroProps) {
               }}
             >
               <div
-                className="max-w-full"
+                className="@container max-w-full"
                 style={{
+                  aspectRatio: !theme.audio ? assetItem.aspectRatio : undefined,
                   width: `${width}%`,
                   minWidth: MIN_PLAYER_WIDTH,
                 }}
@@ -111,6 +112,7 @@ export default function PlayerHero(props: PlayerHeroProps) {
                 <MediaTheme
                   name={props.params.slug}
                   theme={theme}
+                  defaultDuration={assetItem.duration}
                   mediaTitle={assetItem.title}
                   mediaByline={assetItem.byline}
                 >

--- a/site/app/_components/PlayerStyleLogo.tsx
+++ b/site/app/_components/PlayerStyleLogo.tsx
@@ -9,6 +9,8 @@ export default function PlayerStyleLogo({ className }: PlayerStyleLogoProps) {
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 150 30"
+      width="150"
+      height="30"
     >
       <path
         fill="currentColor"

--- a/site/app/_components/ThemePreview.tsx
+++ b/site/app/_components/ThemePreview.tsx
@@ -28,7 +28,7 @@ export default function ThemePreview(props: ThemePreviewProps) {
       <div className="bg-white border-ctx border -m-0.5px relative grid gap-x-2 gap-y-1 p-1 pb-2 md:px-2 md:py-1.5">
         <div className={clsx('w-full', theme.audio ? 'py-2' : undefined)}>
           <div
-            className="max-h-[480px] mx-auto"
+            className="@container max-h-[480px] mx-auto"
             style={{
               aspectRatio: !theme.audio ? assetItem.aspectRatio : undefined,
             }}
@@ -36,7 +36,7 @@ export default function ThemePreview(props: ThemePreviewProps) {
             <MediaTheme
               name={theme._meta.path}
               theme={theme}
-              defaultDuration={63}
+              defaultDuration={assetItem.duration}
               mediaTitle={assetItem.title}
               mediaByline={assetItem.byline}
             >

--- a/site/app/_components/Video.tsx
+++ b/site/app/_components/Video.tsx
@@ -17,13 +17,14 @@ type VideoProps = DetailedHTMLProps<VideoHTMLAttributes<HTMLVideoElement>, HTMLV
   children?: React.ReactNode;
 };
 
-export default function Video(props: VideoProps) {
+export default function Video({ className, ...props }: VideoProps) {
   return (
     <mux-video
       suppressHydrationWarning
       crossOrigin="anonymous"
       playsInline
       cast-src={props.src}
+      class={className}
       {...props}
     >
       {props.children}

--- a/site/content-collections.ts
+++ b/site/content-collections.ts
@@ -18,7 +18,7 @@ const themes = defineCollection({
     description: z.string(),
     author: z.string(),
     audio: z.optional(z.boolean()),
-    height: z.optional(z.number()),
+    themeProps: z.optional(z.record(z.string(), z.any())),
     defaultAsset: z.optional(z.string()),
     tagGroups: z.optional(
       z.object({

--- a/site/media-assets.ts
+++ b/site/media-assets.ts
@@ -6,7 +6,8 @@ const mediaAssets = {
     thumbnails: 'https://image.mux.com/fXNzVtmtWuyz00xnSrJg4OJH6PyNo6D02UzmgeKGkP5YQ/storyboard.vtt',
     aspectRatio: 16 / 9,
     title: 'Landscape Promo',
-    byline: 'by Mux'
+    byline: 'by Mux',
+    duration: 63
   },
   portrait: {
     playbackId: '1EFcsL5JET00t00mBv01t00xt00T4QeNQtsXx2cKY6DLd7RM',
@@ -15,7 +16,8 @@ const mediaAssets = {
     thumbnails: 'https://image.mux.com/1EFcsL5JET00t00mBv01t00xt00T4QeNQtsXx2cKY6DLd7RM/storyboard.vtt',
     aspectRatio: 9 / 16,
     title: 'Portrait Promo',
-    byline: 'by Mux'
+    byline: 'by Mux',
+    duration: 20
   }
 };
 

--- a/site/package.json
+++ b/site/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@content-collections/core": "^0.6.0",
     "@content-collections/next": "^0.2.0",
+    "@tailwindcss/container-queries": "^0.1.1",
     "@types/mdx": "^2.0.13",
     "@types/node": "^20",
     "@types/react": "^18",

--- a/site/tailwind.config.js
+++ b/site/tailwind.config.js
@@ -11,6 +11,7 @@
  */
 import flattenColorPalette from 'tailwindcss/lib/util/flattenColorPalette';
 import plugin from 'tailwindcss/plugin';
+import containerQueries from '@tailwindcss/container-queries';
 
 const context = plugin(({ matchUtilities, addUtilities, theme }) => {
   matchUtilities(
@@ -159,9 +160,14 @@ const spacing = {
 
 /** @type {import('tailwindcss').Config} */
 export default {
+  safelist: [
+    '@[480px]:h-[98px]',                // Sutro audio
+    '@[0px]:h-[88px]', '@md:h-[64px]',  // Tailwind audio
+    '@[0px]:h-[264px]'                  // Winamp
+  ],
   content: ['./app/**/*.{js,ts,jsx,tsx,mdx}'],
   darkMode: 'class',
-  plugins: [context, ligatures, darkColorScheme, nestedDecimalLists, buildGrids],
+  plugins: [context, ligatures, darkColorScheme, nestedDecimalLists, buildGrids, containerQueries],
   theme: {
     extend: {
       gridTemplateColumns: ({ theme }) => ({

--- a/site/themes/sutro-audio.md
+++ b/site/themes/sutro-audio.md
@@ -4,6 +4,8 @@ author: '@muxinc'
 date: 2024-07
 description: A sleek and modern theme lovingly named after our favorite SF TV antenna, which is neither sleek nor modern.
 audio: true
+themeProps:
+  className: '@[480px]:h-[98px]'
 tagGroups:
   media: 
     - Audio

--- a/site/themes/tailwind-audio.md
+++ b/site/themes/tailwind-audio.md
@@ -4,6 +4,8 @@ author: '@luwes'
 date: '2023'
 description: A slick, minimal audio player theme made with Tailwind CSS.
 audio: true
+themeProps:
+  className: '@[0px]:h-[88px] @md:h-[64px]'
 tagGroups:
   media: 
     - Audio

--- a/site/themes/winamp.md
+++ b/site/themes/winamp.md
@@ -4,6 +4,8 @@ author: '@maveio'
 date: '2022'
 description: A retro theme inspired by the classic Winamp media player
 audio: true
+themeProps:
+  className: '@[0px]:h-[264px]'
 tagGroups:
   media: 
     - Video


### PR DESCRIPTION
fix #91

- fixes the layout shift in the player (I think) @heff reported
- removes the sticky header, was causing shifting issues in Chrome
- adds a bunch of fixed heights w/ media and container queries
- some small bug fixes