### PR TITLE
site: audio theme overflowing width

### DIFF
--- a/site/app/_components/PlayerHero.tsx
+++ b/site/app/_components/PlayerHero.tsx
@@ -94,7 +94,7 @@ export default function PlayerHero(props: PlayerHeroProps) {
               ref={playerContainer}
               className={clsx(
                 'flex items-center justify-center dark max-h-[719px] mx-auto overflow-hidden',
-                theme.audio && 'sm:p-1 md:p-2'
+                theme.audio && 'max-w-full sm:p-1 md:p-2'
               )}
               style={{
                 aspectRatio: !theme.audio ? assetItem.aspectRatio : undefined,


### PR DESCRIPTION
I had recently removed max-width: 100% for both audio and video because on Safari it made the video for some reason stretch full width in portrait mode while it should have been kept narrow restricted by the max-height and aspect-ratio.

This change adds it back in for audio themes only which seems to be fine on Safari.