### PR TITLE
feat: add typesVersions and CJS support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -535,6 +535,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.0.tgz",
+      "integrity": "sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -11272,10 +11288,418 @@
     "scripts/build-theme": {
       "version": "0.0.6",
       "dependencies": {
-        "ejs": "^3.1.10"
+        "ejs": "^3.1.10",
+        "esbuild": "^0.24.0"
       },
       "bin": {
         "build-theme": "build.js"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz",
+      "integrity": "sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/android-arm": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.0.tgz",
+      "integrity": "sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/android-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.0.tgz",
+      "integrity": "sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/android-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.0.tgz",
+      "integrity": "sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.0.tgz",
+      "integrity": "sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.0.tgz",
+      "integrity": "sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.0.tgz",
+      "integrity": "sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.0.tgz",
+      "integrity": "sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/linux-arm": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.0.tgz",
+      "integrity": "sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.0.tgz",
+      "integrity": "sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.0.tgz",
+      "integrity": "sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.0.tgz",
+      "integrity": "sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.0.tgz",
+      "integrity": "sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.0.tgz",
+      "integrity": "sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.0.tgz",
+      "integrity": "sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.0.tgz",
+      "integrity": "sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/linux-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.0.tgz",
+      "integrity": "sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.0.tgz",
+      "integrity": "sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.0.tgz",
+      "integrity": "sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.0.tgz",
+      "integrity": "sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.0.tgz",
+      "integrity": "sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.0.tgz",
+      "integrity": "sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/@esbuild/win32-x64": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz",
+      "integrity": "sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "scripts/build-theme/node_modules/esbuild": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
+      "integrity": "sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.0",
+        "@esbuild/android-arm": "0.24.0",
+        "@esbuild/android-arm64": "0.24.0",
+        "@esbuild/android-x64": "0.24.0",
+        "@esbuild/darwin-arm64": "0.24.0",
+        "@esbuild/darwin-x64": "0.24.0",
+        "@esbuild/freebsd-arm64": "0.24.0",
+        "@esbuild/freebsd-x64": "0.24.0",
+        "@esbuild/linux-arm": "0.24.0",
+        "@esbuild/linux-arm64": "0.24.0",
+        "@esbuild/linux-ia32": "0.24.0",
+        "@esbuild/linux-loong64": "0.24.0",
+        "@esbuild/linux-mips64el": "0.24.0",
+        "@esbuild/linux-ppc64": "0.24.0",
+        "@esbuild/linux-riscv64": "0.24.0",
+        "@esbuild/linux-s390x": "0.24.0",
+        "@esbuild/linux-x64": "0.24.0",
+        "@esbuild/netbsd-x64": "0.24.0",
+        "@esbuild/openbsd-arm64": "0.24.0",
+        "@esbuild/openbsd-x64": "0.24.0",
+        "@esbuild/sunos-x64": "0.24.0",
+        "@esbuild/win32-arm64": "0.24.0",
+        "@esbuild/win32-ia32": "0.24.0",
+        "@esbuild/win32-x64": "0.24.0"
       }
     },
     "scripts/publish-packages": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,34 @@
   ],
   "type": "module",
   "exports": {
-    "./*/react": "./themes/*/dist/react.js",
-    "./*.js": "./themes/*/dist/media-theme.js",
-    "./*": "./themes/*/dist/media-theme.js"
+    "./*/react": {
+      "types": "./themes/*/dist/react.d.ts",
+      "import": "./themes/*/dist/react.js",
+      "require": "./themes/*/dist/cjs/react.js",
+      "default": "./themes/*/dist/react.js"
+    },
+    "./*.js": {
+      "types": "./themes/*/dist/media-theme.d.ts",
+      "import": "./themes/*/dist/media-theme.js",
+      "require": "./themes/*/dist/cjs/media-theme.js",
+      "default": "./themes/*/dist/media-theme.js"
+    },
+    "./*": {
+      "types": "./themes/*/dist/media-theme.d.ts",
+      "import": "./themes/*/dist/media-theme.js",
+      "require": "./themes/*/dist/cjs/media-theme.js",
+      "default": "./themes/*/dist/media-theme.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*/react": [
+        "./themes/*/dist/react.d.ts"
+      ],
+      "*": [
+        "./themes/*/dist/media-theme.d.ts"
+      ]
+    }
   },
   "workspaces": [
     ".",

--- a/scripts/build-theme/package.json
+++ b/scripts/build-theme/package.json
@@ -8,6 +8,7 @@
     "build-theme": "./build.js"
   },
   "dependencies": {
-    "ejs": "^3.1.10"
+    "ejs": "^3.1.10",
+    "esbuild": "^0.24.0"
   }
 }

--- a/themes/demuxed-2022/package.json
+++ b/themes/demuxed-2022/package.json
@@ -17,10 +17,31 @@
     "dist"
   ],
   "type": "module",
-  "main": "dist/media-theme.js",
+  "types": "./dist/media-theme.d.ts",
+  "main": "./dist/media-theme.js",
   "exports": {
-    ".": "./dist/media-theme.js",
-    "./react": "./dist/react.js"
+    ".": {
+      "types": "./dist/media-theme.d.ts",
+      "import": "./dist/media-theme.js",
+      "require": "./dist/cjs/media-theme.js",
+      "default": "./dist/media-theme.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/cjs/react.js",
+      "default": "./dist/react.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "react": [
+        "./dist/react.d.ts"
+      ],
+      "*": [
+        "./dist/media-theme.d.ts"
+      ]
+    }
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/themes/instaplay/package.json
+++ b/themes/instaplay/package.json
@@ -17,10 +17,31 @@
     "dist"
   ],
   "type": "module",
-  "main": "dist/media-theme.js",
+  "types": "./dist/media-theme.d.ts",
+  "main": "./dist/media-theme.js",
   "exports": {
-    ".": "./dist/media-theme.js",
-    "./react": "./dist/react.js"
+    ".": {
+      "types": "./dist/media-theme.d.ts",
+      "import": "./dist/media-theme.js",
+      "require": "./dist/cjs/media-theme.js",
+      "default": "./dist/media-theme.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/cjs/react.js",
+      "default": "./dist/react.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "react": [
+        "./dist/react.d.ts"
+      ],
+      "*": [
+        "./dist/media-theme.d.ts"
+      ]
+    }
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/themes/microvideo/package.json
+++ b/themes/microvideo/package.json
@@ -17,10 +17,31 @@
     "dist"
   ],
   "type": "module",
-  "main": "dist/media-theme.js",
+  "types": "./dist/media-theme.d.ts",
+  "main": "./dist/media-theme.js",
   "exports": {
-    ".": "./dist/media-theme.js",
-    "./react": "./dist/react.js"
+    ".": {
+      "types": "./dist/media-theme.d.ts",
+      "import": "./dist/media-theme.js",
+      "require": "./dist/cjs/media-theme.js",
+      "default": "./dist/media-theme.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/cjs/react.js",
+      "default": "./dist/react.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "react": [
+        "./dist/react.d.ts"
+      ],
+      "*": [
+        "./dist/media-theme.d.ts"
+      ]
+    }
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/themes/minimal/package.json
+++ b/themes/minimal/package.json
@@ -17,10 +17,31 @@
     "dist"
   ],
   "type": "module",
-  "main": "dist/media-theme.js",
+  "types": "./dist/media-theme.d.ts",
+  "main": "./dist/media-theme.js",
   "exports": {
-    ".": "./dist/media-theme.js",
-    "./react": "./dist/react.js"
+    ".": {
+      "types": "./dist/media-theme.d.ts",
+      "import": "./dist/media-theme.js",
+      "require": "./dist/cjs/media-theme.js",
+      "default": "./dist/media-theme.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/cjs/react.js",
+      "default": "./dist/react.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "react": [
+        "./dist/react.d.ts"
+      ],
+      "*": [
+        "./dist/media-theme.d.ts"
+      ]
+    }
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/themes/notflix/package.json
+++ b/themes/notflix/package.json
@@ -17,10 +17,31 @@
     "dist"
   ],
   "type": "module",
-  "main": "dist/media-theme.js",
+  "types": "./dist/media-theme.d.ts",
+  "main": "./dist/media-theme.js",
   "exports": {
-    ".": "./dist/media-theme.js",
-    "./react": "./dist/react.js"
+    ".": {
+      "types": "./dist/media-theme.d.ts",
+      "import": "./dist/media-theme.js",
+      "require": "./dist/cjs/media-theme.js",
+      "default": "./dist/media-theme.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/cjs/react.js",
+      "default": "./dist/react.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "react": [
+        "./dist/react.d.ts"
+      ],
+      "*": [
+        "./dist/media-theme.d.ts"
+      ]
+    }
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/themes/reelplay/package.json
+++ b/themes/reelplay/package.json
@@ -17,10 +17,31 @@
     "dist"
   ],
   "type": "module",
-  "main": "dist/media-theme.js",
+  "types": "./dist/media-theme.d.ts",
+  "main": "./dist/media-theme.js",
   "exports": {
-    ".": "./dist/media-theme.js",
-    "./react": "./dist/react.js"
+    ".": {
+      "types": "./dist/media-theme.d.ts",
+      "import": "./dist/media-theme.js",
+      "require": "./dist/cjs/media-theme.js",
+      "default": "./dist/media-theme.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/cjs/react.js",
+      "default": "./dist/react.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "react": [
+        "./dist/react.d.ts"
+      ],
+      "*": [
+        "./dist/media-theme.d.ts"
+      ]
+    }
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/themes/sutro-audio/package.json
+++ b/themes/sutro-audio/package.json
@@ -17,10 +17,31 @@
     "dist"
   ],
   "type": "module",
-  "main": "dist/media-theme.js",
+  "types": "./dist/media-theme.d.ts",
+  "main": "./dist/media-theme.js",
   "exports": {
-    ".": "./dist/media-theme.js",
-    "./react": "./dist/react.js"
+    ".": {
+      "types": "./dist/media-theme.d.ts",
+      "import": "./dist/media-theme.js",
+      "require": "./dist/cjs/media-theme.js",
+      "default": "./dist/media-theme.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/cjs/react.js",
+      "default": "./dist/react.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "react": [
+        "./dist/react.d.ts"
+      ],
+      "*": [
+        "./dist/media-theme.d.ts"
+      ]
+    }
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/themes/sutro/package.json
+++ b/themes/sutro/package.json
@@ -17,10 +17,31 @@
     "dist"
   ],
   "type": "module",
-  "main": "dist/media-theme.js",
+  "types": "./dist/media-theme.d.ts",
+  "main": "./dist/media-theme.js",
   "exports": {
-    ".": "./dist/media-theme.js",
-    "./react": "./dist/react.js"
+    ".": {
+      "types": "./dist/media-theme.d.ts",
+      "import": "./dist/media-theme.js",
+      "require": "./dist/cjs/media-theme.js",
+      "default": "./dist/media-theme.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/cjs/react.js",
+      "default": "./dist/react.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "react": [
+        "./dist/react.d.ts"
+      ],
+      "*": [
+        "./dist/media-theme.d.ts"
+      ]
+    }
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/themes/tailwind-audio/package.json
+++ b/themes/tailwind-audio/package.json
@@ -17,10 +17,31 @@
     "dist"
   ],
   "type": "module",
-  "main": "dist/media-theme.js",
+  "types": "./dist/media-theme.d.ts",
+  "main": "./dist/media-theme.js",
   "exports": {
-    ".": "./dist/media-theme.js",
-    "./react": "./dist/react.js"
+    ".": {
+      "types": "./dist/media-theme.d.ts",
+      "import": "./dist/media-theme.js",
+      "require": "./dist/cjs/media-theme.js",
+      "default": "./dist/media-theme.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/cjs/react.js",
+      "default": "./dist/react.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "react": [
+        "./dist/react.d.ts"
+      ],
+      "*": [
+        "./dist/media-theme.d.ts"
+      ]
+    }
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/themes/vimeonova/package.json
+++ b/themes/vimeonova/package.json
@@ -17,10 +17,31 @@
     "dist"
   ],
   "type": "module",
-  "main": "dist/media-theme.js",
+  "types": "./dist/media-theme.d.ts",
+  "main": "./dist/media-theme.js",
   "exports": {
-    ".": "./dist/media-theme.js",
-    "./react": "./dist/react.js"
+    ".": {
+      "types": "./dist/media-theme.d.ts",
+      "import": "./dist/media-theme.js",
+      "require": "./dist/cjs/media-theme.js",
+      "default": "./dist/media-theme.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/cjs/react.js",
+      "default": "./dist/react.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "react": [
+        "./dist/react.d.ts"
+      ],
+      "*": [
+        "./dist/media-theme.d.ts"
+      ]
+    }
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/themes/winamp/package.json
+++ b/themes/winamp/package.json
@@ -17,10 +17,31 @@
     "dist"
   ],
   "type": "module",
-  "main": "dist/media-theme.js",
+  "types": "./dist/media-theme.d.ts",
+  "main": "./dist/media-theme.js",
   "exports": {
-    ".": "./dist/media-theme.js",
-    "./react": "./dist/react.js"
+    ".": {
+      "types": "./dist/media-theme.d.ts",
+      "import": "./dist/media-theme.js",
+      "require": "./dist/cjs/media-theme.js",
+      "default": "./dist/media-theme.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/cjs/react.js",
+      "default": "./dist/react.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "react": [
+        "./dist/react.d.ts"
+      ],
+      "*": [
+        "./dist/media-theme.d.ts"
+      ]
+    }
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/themes/yt/package.json
+++ b/themes/yt/package.json
@@ -17,10 +17,31 @@
     "dist"
   ],
   "type": "module",
-  "main": "dist/media-theme.js",
+  "types": "./dist/media-theme.d.ts",
+  "main": "./dist/media-theme.js",
   "exports": {
-    ".": "./dist/media-theme.js",
-    "./react": "./dist/react.js"
+    ".": {
+      "types": "./dist/media-theme.d.ts",
+      "import": "./dist/media-theme.js",
+      "require": "./dist/cjs/media-theme.js",
+      "default": "./dist/media-theme.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js",
+      "require": "./dist/cjs/react.js",
+      "default": "./dist/react.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "react": [
+        "./dist/react.d.ts"
+      ],
+      "*": [
+        "./dist/media-theme.d.ts"
+      ]
+    }
   },
   "scripts": {
     "clean": "rimraf dist",


### PR DESCRIPTION
fix #92

the package.json `exports` field is only used with moduleResolution `node16`, `nodenext` or `bundler`.
so the default moduleResolution `node` uses `typesVersions`.