### PR TITLE
fix: yt theme media caption button underline

### DIFF
--- a/themes/yt/template.html
+++ b/themes/yt/template.html
@@ -384,7 +384,7 @@
         width: 0;
         height: 3px;
         border-radius: 3px;
-        background-color: #f00;
+        background-color: var(--media-accent-color, #f00);
         bottom: 19%;
         left: 50%;
         transition: all 0.1s cubic-bezier(0, 0, 0.2, 1), width 0.1s cubic-bezier(0, 0, 0.2, 1);


### PR DESCRIPTION
![Screenshot 2024-11-09 at 00 25 58](https://github.com/user-attachments/assets/4a895fc2-1adb-432c-8093-ad709297078f)

Updates the CC button underline color so that it uses accent color.