### PR TITLE
fix: exclude build-theme

### DIFF
--- a/.github/release-please/.release-please-manifest.json
+++ b/.github/release-please/.release-please-manifest.json
@@ -1,7 +1,6 @@
 {
   ".": "0.0.12",
   "examples/vanilla": "1.6.0",
-  "scripts/build-theme": "0.0.8",
   "site": "1.6.0",
   "themes/demuxed-2022": "0.0.12",
   "themes/halloween": "0.0.2",

--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -13,10 +13,6 @@
       "draft": true,
       "skip-github-release": true
     },
-    "scripts/build-theme": {
-      "draft": true,
-      "skip-github-release": true
-    },
     "site": {
       "draft": true,
       "skip-github-release": true


### PR DESCRIPTION
build-theme doesn't need version bumps as it is symlinked via NPM workspaces. the problem was if it is excluded from github releases new Git tags are not pushed either making release please keep on creating a new PR for version bumping build-theme and then also all dependants (themes)