### PR TITLE
fix: hide controls until breakpoints set

### DIFF
--- a/themes/sutro/template.html
+++ b/themes/sutro/template.html
@@ -32,6 +32,10 @@
     --base: 20px;
   }
 
+  media-controller:not([breakpointset]) media-control-bar {
+    visibility: hidden;
+  }
+
   /* The biggest size controller is tied to going fullscreen
       instead of a player width */
   media-controller[mediaisfullscreen] {
@@ -68,7 +72,7 @@
 </style>
 
 <media-controller
-  breakpoints="md:480"
+  breakpoints="set:0 md:480"
   defaultsubtitles="{{defaultsubtitles}}"
   defaultduration="{{defaultduration}}"
   gesturesdisabled="{{disabled}}"


### PR DESCRIPTION
this fixes a visual glitch for larger views where if the breakpoints are not available yet the "small" view is shown for a split second until the breakpoints are available. 

the fix is to hide only the controls since we want to show the media, poster and gradient. 
everything that is not responsive should be shown.