### PR TITLE
docs: update README with media-chrome dependency handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ Visit [player.style](https://player.style).
 
 # Local Development
 
-This is a monorepo that uses NPM workspaces and Turbo. The root package is
-also a published package which currently makes it impossible to have similar
-named NPM scripts in the root package and the workspace packages. 
+This is a monorepo that uses NPM workspaces and Turbo. The root package is also a published package, which currently prevents having identically named NPM scripts in both the root and workspace packages.
 
 For this reason we use the `turbo` CLI directly in the root directory.
 
@@ -16,3 +14,29 @@ For this reason we use the `turbo` CLI directly in the root directory.
 1. Clone the repository
 1. Run `npm install`
 1. Run `turbo build`
+
+### Handling Dependency Conflicts with `media-chrome`
+
+If your project already includes `media-chrome` and you encounter dependency conflicts, you can override the resolution to ensure compatibility.
+
+#### Solution: Using `overrides` in `package.json` (for npm 8+)
+
+If you're using **npm** 8 or later, you can enforce a specific version of `media-chrome` in your `package.json` by adding an `overrides` field:
+
+```json
+{
+  "overrides": {
+    "media-chrome": "<your-desired-version>"
+  }
+}
+```
+
+If you’re using **Yarn**, you can enforce a specific version with the resolutions field:
+
+```json
+{
+  "resolutions": {
+    "media-chrome": "<your-desired-version>"
+  }
+}
+```


### PR DESCRIPTION
This PR updates the README to document potential conflicts with media-chrome when it is installed as a direct dependency in a project. 

Solve this [Issue](https://github.com/muxinc/player.style/issues/96)