### PR TITLE
Add centered-chrome to Sutro Theme

### DIFF
--- a/site/app/_components/DocsEmbed.tsx
+++ b/site/app/_components/DocsEmbed.tsx
@@ -179,13 +179,14 @@ function reactCode(
   mediaPackage: string,
   customProperties: CustomProperties,
   embed: string,
-  theme: any,
+  theme: any
 ) {
   let imports = [];
   let templateHtml = '';
-  let componentBody = '';
+
   let themeTag = `media-theme-${name}`;
   let themeAttrs = '';
+
   let mediaTag: string = mediaElement.tag;
   const mediaAttrs = attrsToJSXProps(getMediaAttributes(mediaElement));
 
@@ -195,45 +196,23 @@ function reactCode(
   }
 
   if (embed === 'template') {
-    themeAttrs += `\n        template={templateRef.current}`;
+    themeAttrs += `\n        template="media-theme-${name}"`;
     themeTag = 'media-theme';
 
-    imports.push(`import { useEffect, useRef, useState } from 'react';`);
     imports.push(`import 'media-chrome/react';`);
     imports.push(`import 'media-chrome/react/menu';`);
-    imports.push(
-      `import { MediaTheme } from 'media-chrome/react/media-theme';`,
-    );
+    imports.push(`import { MediaTheme } from 'media-chrome/react/media-theme';`);
 
     templateHtml = `<template
-        ref={templateRef}
         id="media-theme-${name}"
         dangerouslySetInnerHTML={{ __html: \`
 ${theme.templates.html.content.trim().replace(/^(.)/gm, '          $1')}\` }}
       />\n\n      `;
+  }
 
-    themeTag = pascalCase(themeTag);
+  themeTag = pascalCase(themeTag);
 
-    componentBody = `
-  const templateRef = useRef<HTMLTemplateElement | null>(null);
-  const [isReady, setIsReady] = useState(false);
-
-  useEffect(() => {
-    const template = templateRef.current;
-    if (!template) return;
-
-    if (!document.getElementById(template.id)) {
-      const clone = document.createElement('template');
-      clone.id = template.id;
-      clone.innerHTML = template.innerHTML;
-      document.body.appendChild(clone);
-    }
-
-    setIsReady(true);
-  }, []);
-`;
-  } else {
-    themeTag = pascalCase(themeTag);
+  if (embed !== 'template') {
     imports.push(`import ${themeTag} from 'player.style/${name}/react';`);
   }
 
@@ -253,27 +232,18 @@ ${theme.templates.html.content.trim().replace(/^(.)/gm, '          $1')}\` }}
 
   if (themeAttrs.length) themeAttrs += '\n      ';
 
-  const templateCondition = embed === 'template'
-    ? `\n      ${templateHtml}
-    {isReady && templateRef.current && (`
-    : '';
-
-  const closingTemplateCondition = embed === 'template'
-    ? `)}`
-    : '';
-
   return [
     {
       lang: 'jsx',
       code: [
         ...imports,
         '',
-        `export default function Page() {${componentBody}
+        `export default function Page() {
   return (
-    <>${templateCondition}
-      <${themeTag}${themeAttrs} style={{width: "100%"}}>
+    <>
+      ${templateHtml}<${themeTag}${themeAttrs} style={{width: "100%"}}>
         <${mediaTag}${getIndentedAttributes(mediaAttrs, 8)}></${mediaTag}>
-      </${themeTag}>${closingTemplateCondition}
+      </${themeTag}>
     </>
   );
 }`,
@@ -490,8 +460,8 @@ function getMediaAttributes(mediaElement: any) {
 }
 
 const attrsToJSXPropsMap: Record<string, string> = {
-  playsinline: 'playsInline',
-  crossorigin: 'crossOrigin',
+  'playsinline': 'playsInline',
+  'crossorigin': 'crossOrigin',
 };
 
 function attrsToJSXProps(attrs: Record<string, any>) {

--- a/themes/sutro/template.html
+++ b/themes/sutro/template.html
@@ -78,6 +78,7 @@
 >
   <slot name="media" slot="media"></slot>
   <slot name="poster" slot="poster"></slot>
+  <slot name="centered-chrome" slot="centered-chrome"></slot>
   <media-error-dialog slot="dialog"></media-error-dialog>
 
   <!-- Controls Gradient -->
@@ -161,7 +162,7 @@
       display: none;
     }
 
-    /* Also hide if only `Auto` is added. */
+    /* Also hide if only 'Auto' is added. */
     .quality-settings[submenusize='1'] {
       display: none;
     }
@@ -419,7 +420,7 @@
       media-volume-range {
         /*
           Hide range and animation until mediavolume attribute is set.
-          `visibility` didn't work, hovering over media-volume-range-wrapper
+          'visibility' didn't work, hovering over media-volume-range-wrapper
           caused it to show. Should require mute-button:hover.
         */
         opacity: 0;


### PR DESCRIPTION
This PR addresses the **[Issue #192](https://github.com/muxinc/player.style/issues/192)**: Adds a new `centered-chrome` slot to the **Sutro** theme, allowing developers to insert custom elements in the center UI area. This region is designed to hide during playback or when the mouse is idle.

- Additionally, this PR modifies the use of single backtick **&#96;text&#96;** characters in the Sutro theme, which could cause implementation errors in JSX environments.


Preview:

<img width="623" height="338" alt="image" src="https://github.com/user-attachments/assets/1fc33308-7f6b-45f7-b7a0-46e55ab493e5" />