### PR TITLE
feat:: Add centered chrome with animated play button in YT theme

### DIFF
--- a/themes/yt/template.html
+++ b/themes/yt/template.html
@@ -123,7 +123,7 @@
       display: none;
     }
 
-    /* Also hide if only `Auto` is added. */
+    /* Also hide if only 'Auto' is added. */
     .quality-settings[submenusize='1'] {
       display: none;
     }
@@ -224,7 +224,7 @@
         --media-button-icon-width: 30px;
         padding: 6px 10px;
       }
-      
+
       media-play-button #icon-play,
       media-play-button #icon-pause {
         filter: drop-shadow(0 0 2px #00000080);
@@ -538,54 +538,107 @@
     </media-fullscreen-button>
   </media-control-bar>
 
-<style>
-  media-play-button[slot='centered-chrome'] {
-    --media-button-icon-width: 60px;
-    --media-button-icon-height: 60px;
-    width: 50%;
-    height: 50%;
-    position: relative;
-  }
-
-  /* Always hide svg in current time 0 */
-  media-controller[mediacurrenttime="0"] media-play-button[slot="centered-chrome"] > svg {
-    display: none !important;
-  }
-
-  media-play-button[slot='centered-chrome'] > svg {
-    width: 3rem;
-    height: 3rem;
-    opacity: 0;
-    transform: scale(1);
-    pointer-events: none;
-  }
-
-  media-play-button[slot='centered-chrome'] > svg[slot="play"],
-  media-play-button[slot='centered-chrome'] > svg[slot="pause"] {
-    animation: fadeScale 1s ease-out forwards;
-  }
-
-  @keyframes fadeScale {
-    0% {
-      opacity: 1;
-      transform: scale(1);
+  <style>
+    media-controller[mediacurrenttime^='0'] .desktop-centered-animation svg {
+      display: none !important;
+      animation-name: none !important;
+      opacity: 0 !important;
     }
-    100% {
+
+    @media (width <= 768px) {
+      .desktop-centered-animation {
+        display: none;
+      }
+    }
+
+    .desktop-centered-animation media-play-button {
+      width: 48px;
+      height: 48px;
+      position: relative;
+    }
+
+    .desktop-centered-animation media-play-button > svg {
+      width: 3rem;
+      height: 3rem;
       opacity: 0;
-      transform: scale(2);
+      transform: scale(1);
+      pointer-events: none;
+      display: none;
+      animation: none !important;
     }
-  }
-</style>
-  <media-play-button slot="centered-chrome">
-    <svg slot="pause" width="41" height="41" viewBox="0 0 41 41" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <circle cx="20.5" cy="20.5" r="20.5" fill="black" fill-opacity="0.8" />
-      <path d="M28 20.5L16 27.8612L16 13.1388L28 20.5Z" fill="#D9D9D9" />
-    </svg>
 
-    <svg slot="play" width="41" height="41" viewBox="0 0 41 41" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <circle cx="20.5" cy="20.5" r="20.5" fill="black" fill-opacity="0.8" />
-      <path d="M17.7674 13H14V28.0698H17.7674V13Z" fill="#D9D9D9" />
-      <path d="M22.4768 13H26.2442V28.0698H22.4768V13Z" fill="#D9D9D9" />
-    </svg>
-  </media-play-button>
+    media-controller:not([mediacurrenttime^='0']) .desktop-centered-animation media-play-button > svg[slot='play'],
+    media-controller:not([mediacurrenttime^='0']) .desktop-centered-animation media-play-button > svg[slot='pause'] {
+      display: block;
+      animation: fadeScale 1s ease-out forwards;
+    }
+
+    @keyframes fadeScale {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(2);
+      }
+    }
+
+    .mobile-centered-controls {
+      display: flex;
+      align-self: stretch;
+      align-items: center;
+      flex-flow: row nowrap;
+      justify-content: center;
+      margin: -5% auto 0;
+      width: 100%;
+      gap: 1rem;
+    }
+
+    .mobile-centered-controls [role='button'] {
+      --media-icon-color: var(--media-primary-color, #fff);
+      background: rgba(0, 0, 0, 0.5);
+      --media-button-icon-width: 36px;
+      --media-button-icon-height: 36px;
+      border-radius: 50%;
+      user-select: none;
+      aspect-ratio: 1;
+    }
+
+    .mobile-centered-controls media-play-button {
+      width: 5rem;
+    }
+
+    .mobile-centered-controls :is(media-seek-backward-button, media-seek-forward-button) {
+      width: 3rem;
+      padding: 0.5rem;
+    }
+
+    @media (width >= 768px) {
+      .mobile-centered-controls {
+        display: none;
+      }
+    }
+  </style>
+
+  <div class="mobile-centered-controls" slot="centered-chrome">
+    <media-seek-backward-button></media-seek-backward-button>
+    <media-play-button></media-play-button>
+    <media-seek-forward-button></media-seek-forward-button>
+  </div>
+
+  <div class="desktop-centered-animation" slot="centered-chrome">
+    <media-play-button>
+      <svg slot="pause" width="41" height="41" viewBox="0 0 41 41" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20.5" cy="20.5" r="20.5" fill="black" fill-opacity="0.8" />
+        <path d="M28 20.5L16 27.8612L16 13.1388L28 20.5Z" fill="#D9D9D9" />
+      </svg>
+
+      <svg slot="play" width="41" height="41" viewBox="0 0 41 41" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="20.5" cy="20.5" r="20.5" fill="black" fill-opacity="0.8" />
+        <path d="M17.7674 13H14V28.0698H17.7674V13Z" fill="#D9D9D9" />
+        <path d="M22.4768 13H26.2442V28.0698H22.4768V13Z" fill="#D9D9D9" />
+      </svg>
+    </media-play-button>
+  </div>
 </media-controller>

--- a/themes/yt/template.html
+++ b/themes/yt/template.html
@@ -536,7 +536,6 @@
     width: 50%;
     height: 50%;
     position: relative;
-    background: red;
   }
 
   /* Always hide svg in current time 0 */

--- a/themes/yt/template.html
+++ b/themes/yt/template.html
@@ -224,6 +224,11 @@
         --media-button-icon-width: 30px;
         padding: 6px 10px;
       }
+      
+      media-play-button #icon-play,
+      media-play-button #icon-pause {
+        filter: drop-shadow(0 0 2px #00000080);
+      }
 
       media-play-button :is(#play-p1, #play-p2, #pause-p1, #pause-p2) {
         transition: clip-path 0.25s ease-in;
@@ -258,12 +263,15 @@
     </style>
     <media-play-button mediapaused class="yt-button">
       <svg slot="icon" viewBox="0 0 36 36">
-        <use class="svg-shadow" xlink:href="#icon-play"></use>
         <g id="icon-play">
+        <g id="play-icon">
           <path id="play-p1" d="M18.5 14L12 10V26L18.5 22V14Z" />
           <path id="play-p2" d="M18 13.6953L25 18L18 22.3086V13.6953Z" />
+        </g>
+        <g id="pause-icon">
           <path id="pause-p1" d="M16 10H12V26H16V10Z" />
           <path id="pause-p2" d="M21 10H25V26H21V10Z" />
+        </g>
         </g>
       </svg>
     </media-play-button>
@@ -319,6 +327,7 @@
     </style>
     <media-mute-button class="yt-button">
       <svg slot="icon" viewBox="0 0 36 36">
+        <use class="svg-shadow" xlink:href="#icon-volume"></use>
         <g id="icon-volume">
           <path id="speaker" d="M13 15H9V21H13L18 26V10L13 15Z" />
           <path

--- a/themes/yt/template.html
+++ b/themes/yt/template.html
@@ -68,6 +68,7 @@
 >
   <slot name="media" slot="media"></slot>
   <slot name="poster" slot="poster"></slot>
+  <slot name="centered-chrome" slot="centered-chrome"></slot>
   <media-error-dialog slot="dialog"></media-error-dialog>
 
   <!-- Gradient -->
@@ -388,20 +389,26 @@
         background-color: var(--media-accent-color, #f00);
         bottom: 19%;
         left: 50%;
-        transition: all 0.1s cubic-bezier(0, 0, 0.2, 1), width 0.1s cubic-bezier(0, 0, 0.2, 1);
+        transition:
+          all 0.1s cubic-bezier(0, 0, 0.2, 1),
+          width 0.1s cubic-bezier(0, 0, 0.2, 1);
       }
 
       media-captions-button[mediasubtitleslist][aria-checked='true']:after {
         left: 25%;
         width: 50%;
-        transition: left 0.25s cubic-bezier(0, 0, 0.2, 1), width 0.25s cubic-bezier(0, 0, 0.2, 1);
+        transition:
+          left 0.25s cubic-bezier(0, 0, 0.2, 1),
+          width 0.25s cubic-bezier(0, 0, 0.2, 1);
       }
 
       media-captions-button[mediasubtitleslist][aria-checked='true']:after {
         left: 25%;
         width: 50%;
 
-        transition: left 0.25s cubic-bezier(0, 0, 0.2, 1), width 0.25s cubic-bezier(0, 0, 0.2, 1);
+        transition:
+          left 0.25s cubic-bezier(0, 0, 0.2, 1),
+          width 0.25s cubic-bezier(0, 0, 0.2, 1);
       }
     </style>
     <media-captions-button class="yt-button">
@@ -521,4 +528,56 @@
       </svg>
     </media-fullscreen-button>
   </media-control-bar>
+
+<style>
+  media-play-button[slot='centered-chrome'] {
+    --media-button-icon-width: 60px;
+    --media-button-icon-height: 60px;
+    width: 50%;
+    height: 50%;
+    position: relative;
+    background: red;
+  }
+
+  /* Always hide svg in current time 0 */
+  media-controller[mediacurrenttime="0"] media-play-button[slot="centered-chrome"] > svg {
+    display: none !important;
+  }
+
+  media-play-button[slot='centered-chrome'] > svg {
+    width: 3rem;
+    height: 3rem;
+    opacity: 0;
+    transform: scale(1);
+    pointer-events: none;
+  }
+
+  media-play-button[slot='centered-chrome'] > svg[slot="play"],
+  media-play-button[slot='centered-chrome'] > svg[slot="pause"] {
+    animation: fadeScale 1s ease-out forwards;
+  }
+
+  @keyframes fadeScale {
+    0% {
+      opacity: 1;
+      transform: scale(1);
+    }
+    100% {
+      opacity: 0;
+      transform: scale(2);
+    }
+  }
+</style>
+  <media-play-button slot="centered-chrome">
+    <svg slot="pause" width="41" height="41" viewBox="0 0 41 41" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="20.5" cy="20.5" r="20.5" fill="black" fill-opacity="0.8" />
+      <path d="M28 20.5L16 27.8612L16 13.1388L28 20.5Z" fill="#D9D9D9" />
+    </svg>
+
+    <svg slot="play" width="41" height="41" viewBox="0 0 41 41" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <circle cx="20.5" cy="20.5" r="20.5" fill="black" fill-opacity="0.8" />
+      <path d="M17.7674 13H14V28.0698H17.7674V13Z" fill="#D9D9D9" />
+      <path d="M22.4768 13H26.2442V28.0698H22.4768V13Z" fill="#D9D9D9" />
+    </svg>
+  </media-play-button>
 </media-controller>


### PR DESCRIPTION
This PR solves [Issue 136](https://github.com/muxinc/player.style/issues/136)  [watch video](https://player.mux.com/7adph1NWflD2kt8cxXnlT49brrU14VbhgwT005N902FR8?metadata-video-title=Screen+Recording+2025-07-23+at+3&video-title=Screen+Recording+2025-07-23+at+3)

The Issue:

- On Mobile, tapping does not toggle playback, only shows controls and in the YT theme the play button it's really small for touch screen.

Proposed Solution:

- Add a centered-chrome  in the theme.
- Include a media-play-button that covers 50% of the video element (red rectangle on the video sample)
- YouTube-style animation for play/pause event on centered-chrome

All this logic is for Mobile on desktop it keeps toggles playback on click anywhere.

Note: The 50% coverage (red rectangle) it's meant to prevent play/pause trying to improve UX when user want the controls appear on tap on mobile.

Plus: 

- Correct [bug](https://github.com/muxinc/player.style/issues/48) by making the shadow with filter instead of stroke and grouping parts of the icons play/pause 
