### PR TITLE
Add index.js to Warn Against Naked Imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+console.warn(
+  '⚠️ Warning: "player.style" does not export anything by default.\n' +
+  'Please import a specific theme, like:\n' +
+  '  import "player.style/[theme-id]";\n'
+);

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
     "url": "git+https://github.com/muxinc/player.style.git"
   },
   "files": [
+    "index.js",
     "themes/*",
     "!.*"
   ],
   "type": "module",
+  "main": "index.js",
   "exports": {
     "./*/react": {
       "types": "./themes/*/dist/react.d.ts",
@@ -35,6 +37,9 @@
       "import": "./themes/*/dist/media-theme.js",
       "require": "./themes/*/dist/cjs/media-theme.js",
       "default": "./themes/*/dist/media-theme.js"
+    },
+    ".": {
+      "default": "./index.js"
     }
   },
   "typesVersions": {


### PR DESCRIPTION
This PR addresses issue [#132](https://github.com/muxinc/player.style/issues/132) by introducing an index.js file in the root of the player.style package. Previously, importing player.style without specifying a theme (a “naked import”) would result in a build failure due to the absence of a default export.

The newly added `index.js` file contains a console.warn() statement that notifies developers about the missing default export and advises them to import a specific theme instead. This change ensures that the build process continues without interruption while providing clear guidance to developers on how to correctly use the package.