### PR TITLE
Feat/minimal theme video title

### DIFF
--- a/themes/minimal/template.html
+++ b/themes/minimal/template.html
@@ -265,11 +265,18 @@
   <media-loading-indicator slot="centered-chrome" noautohide></media-loading-indicator>
   <media-error-dialog slot="dialog"></media-error-dialog>
 
-  <template if="title">
-    <div slot="top-chrome">
-      <media-text-display>{{title}}</media-text-display>
-    </div>
-  </template>
+  <div slot="top-chrome">
+    <template if="videotitle">
+      <template if="videotitle != true">
+        <media-text-display part="top title display" class="title-display">{{videotitle}}</media-text-display>
+      </template>
+    </template>
+    <template if="!videotitle">
+      <template if="title">
+        <media-text-display part="top title display" class="title-display">{{title}}</media-text-display>
+      </template>
+    </template>
+  </div>
 
   <template if="streamtype == 'on-demand'">
     <template if="!breakpointsm">


### PR DESCRIPTION
This PR adds support for rendering the `video-title` attribute in the minimal theme. resolves [Issue 1172](https://github.com/muxinc/elements/issues/1172)

- Added support for `video-title` in the minimal theme for mux-player integration.