### PR TITLE
build(deps): Bump media-chrome

### DIFF
--- a/examples/remix/package.json
+++ b/examples/remix/package.json
@@ -16,7 +16,7 @@
     "@remix-run/react": "^2.15.1",
     "@remix-run/serve": "^2.15.1",
     "isbot": "^5.1.18",
-    "media-chrome": "^4.16.1",
+    "media-chrome": "^4.19.0",
     "player.style": "^0.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,13 @@
         "themes/*"
       ],
       "dependencies": {
-        "media-chrome": "~4.18.3"
+        "media-chrome": "~4.19.0"
       },
       "devDependencies": {
         "@player.style/demuxed-2022": "0.1.2",
         "@player.style/halloween": "0.1.2",
         "@player.style/instaplay": "0.1.2",
-        "@player.style/microvideo": "0.1.2",
+        "@player.style/microvideo": "0.1.3",
         "@player.style/minimal": "0.2.1",
         "@player.style/notflix": "0.1.2",
         "@player.style/reelplay": "0.1.2",
@@ -51,7 +51,7 @@
         "@remix-run/react": "^2.15.1",
         "@remix-run/serve": "^2.15.1",
         "isbot": "^5.1.18",
-        "media-chrome": "^4.16.1",
+        "media-chrome": "^4.19.0",
         "player.style": "^0.3.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -13130,9 +13130,9 @@
       }
     },
     "node_modules/media-chrome": {
-      "version": "4.18.3",
-      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.18.3.tgz",
-      "integrity": "sha512-YuS2wY0Fn+2nXGijJYn4+IE0n9wFe3v6SvOZHGNkoxh32T/cCcrXHUWskA+9tyYTONa6JKwKAOJJeO6QOlJLKw==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.19.0.tgz",
+      "integrity": "sha512-HWhDTwts+BSbdPkkB1VsJXp5kvL0IxY7xFT5tBwliM2+89kTPVTnHnev+9it2f9PweANjT/C8/C/S0PW9oyZbA==",
       "license": "MIT",
       "dependencies": {
         "ce-la-react": "^0.3.2"
@@ -15377,8 +15377,7 @@
     },
     "node_modules/player.style": {
       "resolved": "",
-      "link": true,
-      "version": "0.3.2"
+      "link": true
     },
     "node_modules/pluralize": {
       "version": "8.0.0",
@@ -19960,7 +19959,7 @@
         "deepmerge": "^4.3.1",
         "flexsearch": "^0.7.43",
         "hls-video-element": "^1.5.10",
-        "media-chrome": "^4.16.1",
+        "media-chrome": "^4.19.0",
         "next": "14.2.12",
         "next-mdx-remote": "^5.0.0",
         "player.style": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "dev": "chokidar --debounce 50 './themes/*/!(dist|.turbo)' -c 'turbo build --force --filter=./$(dirname {path}) && touch ./site/$(dirname {path}).md'"
   },
   "dependencies": {
-    "media-chrome": "~4.18.3"
+    "media-chrome": "~4.19.0"
   },
   "devDependencies": {
     "@player.style/demuxed-2022": "0.1.2",

--- a/site/package.json
+++ b/site/package.json
@@ -19,7 +19,7 @@
     "deepmerge": "^4.3.1",
     "flexsearch": "^0.7.43",
     "hls-video-element": "^1.5.10",
-    "media-chrome": "^4.16.1",
+    "media-chrome": "^4.19.0",
     "next": "14.2.12",
     "next-mdx-remote": "^5.0.0",
     "player.style": "0.3.2",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk dependency-only update, primarily bumping `media-chrome` across workspaces with corresponding lockfile churn.
> 
> **Overview**
> Bumps `media-chrome` to `4.19.0` across the root package, `site`, and the Remix example.
> 
> Updates `package-lock.json` accordingly (new `media-chrome` tarball/integrity) and includes minor related lockfile version bumps such as `@player.style/microvideo`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 324fc56672a9735745d9c88e1c14949573c1f342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->