### PR TITLE
chore: Migrate deprecated release please

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,7 +40,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           config-file: .github/release-please/release-please-config.json


### PR DESCRIPTION
We were getting this message in release steps ([example](https://github.com/muxinc/player.style/actions/runs/24365605384/job/71156680139)):

`Warning: google-github-actions/release-please-action is deprecated, please use googleapis/release-please-action instead.`

While this was not preventing releases, it was found while checking why the latest release failed ("build" or "chore" commits don't trigger a release) 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that swaps the `release-please` action to its non-deprecated repository; release behavior should remain effectively the same aside from action packaging.
> 
> **Overview**
> Updates the CD workflow to use the non-deprecated `googleapis/release-please-action@v4` in the release job, replacing `google-github-actions/release-please-action@v4` to remove deprecation warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 616c8e7acc52558f72dc29a5b642f631004bd26d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->